### PR TITLE
Use Modification time and not CRC for updates

### DIFF
--- a/station.py
+++ b/station.py
@@ -154,9 +154,13 @@ def prepare_image(client):
     filename = bytes(client).hex() + ".png"
     print("Reading image file:", filename)
 
+    modification_time = os.path.getmtime(filename)
+    creation_time = os.path.getctime(filename)
+    
     pf = open(filename,mode='rb')
     imgData = pf.read()
-    imgVer = binascii.crc32(imgData)
+    imgVer = int(modification_time)<<32|int(creation_time) # This uses the mofidication time of the image to look for the newest one
+    #imgVer = binascii.crc32(imgData) # This uses the CRC of the image to look for a newer one but can fail as on "stock" custom firmware the highest number is used
     pf.close()
 
     file_conv = IMAGE_WORKDIR + str(imgVer) + ".bmp"

--- a/station.py
+++ b/station.py
@@ -255,6 +255,11 @@ def generate_pkt_header(pkt): #hacky- timaccop cannot provide header data
 
 def process_pkt(pkt):
     hdr = generate_pkt_header(pkt)
+    
+    if len(pkt['data']) < 10:
+        print("Received a too short paket")
+        print("data", pkt['data'].hex())
+        return
 
     nonce = bytearray(pkt['data'][-4:])
     nonce.extend(reversed(pkt['src_add']))


### PR DESCRIPTION
On the stock protocol the image with the highest version number will be used to update, 
in your code you use CRC32 which can also be lower, and prevents the image from being updated

This should not break your version of the firmware but makes the Station.py compatible to the default behavior of Dmitrys firmware 