### PR TITLE
Added default baud rate of 115200 for USB to UART Converter ZigBee Adapters

### DIFF
--- a/timaccop.py
+++ b/timaccop.py
@@ -236,7 +236,7 @@ def init(port, pan_id, channel, ext_add, pk):
     pkt_callback = pk
 
     global ser
-    ser = serial.Serial(port, timeout=1)
+    ser = serial.Serial(port, 115200, timeout=1)
     ser.flushInput()
 
     ext_add.reverse()


### PR DESCRIPTION
The CC2531 will continue to work as usual as the USB connection handles the speed.

For boards with an CH340 as example the 9600 default speed is just to slow.